### PR TITLE
Set up Prisma with invoice API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Environment variables for development
+DATABASE_URL="postgresql://USER:PASSWORD@localhost:5432/tax_manager"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ The goal is to provide full autonomy and transparency without relying on externa
 - **Components**: shadcn/ui
 - **Deployment**: Vercel
 
+Prisma is now configured with a basic `Invoice` model under `/prisma`. Run `npx prisma migrate dev` after setting `DATABASE_URL` to initialize the database.
 Not all dependencies might be installed right away. Tech stack is gradually implemented as features are developed.
 
 ## Guidelines

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ pnpm dev
 bun dev
 ```
 
+### Database setup
+
+Prisma is used for database access. Copy `.env.example` to `.env` and adjust the
+`DATABASE_URL` for your PostgreSQL instance. Then run:
+
+```bash
+npx prisma migrate dev --name init
+```
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "tax-manager",
       "version": "0.1.0",
       "dependencies": {
+        "@prisma/client": "^6.10.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.518.0",
@@ -24,6 +25,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.3.4",
+        "prisma": "^6.10.1",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.3.4",
         "typescript": "^5"
@@ -974,6 +976,88 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.10.1.tgz",
+      "integrity": "sha512-Re4pMlcUsQsUTAYMK7EJ4Bw2kg3WfZAAlr8GjORJaK4VOP6LxRQUQ1TuLnxcF42XqGkWQ36q5CQF1yVadANQ6w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/config": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.10.1.tgz",
+      "integrity": "sha512-kz4/bnqrOrzWo8KzYguN0cden4CzLJJ+2VSpKtF8utHS3l1JS0Lhv6BLwpOX6X9yNreTbZQZwewb+/BMPDCIYQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jiti": "2.4.2"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.10.1.tgz",
+      "integrity": "sha512-k2YT53cWxv9OLjW4zSYTZ6Z7j0gPfCzcr2Mj99qsuvlxr8WAKSZ2NcSR0zLf/mP4oxnYG842IMj3utTgcd7CaA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.10.1.tgz",
+      "integrity": "sha512-Q07P5rS2iPwk2IQr/rUQJ42tHjpPyFcbiH7PXZlV81Ryr9NYIgdxcUrwgVOWVm5T7ap02C0dNd1dpnNcSWig8A==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.10.1",
+        "@prisma/engines-version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
+        "@prisma/fetch-engine": "6.10.1",
+        "@prisma/get-platform": "6.10.1"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c.tgz",
+      "integrity": "sha512-ZJFTsEqapiTYVzXya6TUKYDFnSWCNegfUiG5ik9fleQva5Sk3DNyyUi7X1+0ZxWFHwHDr6BZV5Vm+iwP+LlciA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.10.1.tgz",
+      "integrity": "sha512-clmbG/Jgmrc/n6Y77QcBmAUlq9LrwI9Dbgy4pq5jeEARBpRCWJDJ7PWW1P8p0LfFU0i5fsyO7FqRzRB8mkdS4g==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.10.1",
+        "@prisma/engines-version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
+        "@prisma/get-platform": "6.10.1"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.10.1.tgz",
+      "integrity": "sha512-4CY5ndKylcsce9Mv+VWp5obbR2/86SHOLVV053pwIkhVtT9C9A83yqiqI/5kJM9T1v1u1qco/bYjDKycmei9HA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.10.1"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4144,7 +4228,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -5083,6 +5167,32 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prisma": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.10.1.tgz",
+      "integrity": "sha512-khhlC/G49E4+uyA3T3H5PRBut486HD2bDqE2+rvkU0pwk9IAqGFacLFUyIx9Uw+W2eCtf6XGwsp+/strUwMNPw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.10.1",
+        "@prisma/engines": "6.10.1"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6011,7 +6121,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@prisma/client": "^6.10.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.518.0",
@@ -25,6 +26,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
+    "prisma": "^6.10.1",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.4",
     "typescript": "^5"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,30 @@
+// Prisma schema
+// Defines PostgreSQL datasource and Invoice model for invoice management
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Invoice {
+  id          String   @id @default(uuid())
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  clientName  String
+  clientEmail String?
+  issueDate   DateTime
+  dueDate     DateTime
+  amount      Decimal   @db.Decimal(10,2)
+  taxRate     Float
+  status      InvoiceStatus @default(PENDING)
+}
+
+enum InvoiceStatus {
+  PENDING
+  PAID
+  CANCELLED
+}

--- a/src/app/api/invoices/route.ts
+++ b/src/app/api/invoices/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  const invoices = await prisma.invoice.findMany({ orderBy: { issueDate: 'desc' } })
+  return NextResponse.json(invoices)
+}
+
+export async function POST(request: Request) {
+  const data = await request.json()
+
+  // Basic validation
+  if (!data.clientName || !data.issueDate || !data.dueDate || !data.amount) {
+    return NextResponse.json(
+      { error: 'Missing required fields' },
+      { status: 400 }
+    )
+  }
+
+  const invoice = await prisma.invoice.create({
+    data: {
+      clientName: data.clientName,
+      clientEmail: data.clientEmail,
+      issueDate: new Date(data.issueDate),
+      dueDate: new Date(data.dueDate),
+      amount: data.amount,
+      taxRate: data.taxRate ?? 0,
+      status: data.status ?? 'PENDING',
+    },
+  })
+
+  return NextResponse.json(invoice, { status: 201 })
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client'
+
+declare global {
+  var prisma: PrismaClient | undefined
+}
+
+export const prisma = global.prisma ?? new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') global.prisma = prisma


### PR DESCRIPTION
## Summary
- configure Prisma and move its dependency to devDependencies
- set up initial Prisma schema and database config
- expose Prisma client helper
- add invoice API route with basic validation
- tweak gitignore to allow .env.example and document Prisma commands
- update AGENTS and README with Prisma instructions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853ecb47238832892fad494f4c40763