### PR TITLE
Fix Prisma client generation on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ Prisma is used for database access. Copy `.env.example` to `.env` and adjust the
 npx prisma migrate dev --name init
 ```
 
+### Building for production
+
+Before deploying, generate the Prisma client and build the app:
+
+```bash
+npm run build
+```
+
+The `build` script runs `prisma generate` automatically so the latest client is included in your production bundle.
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@prisma/client": "^6.10.1",


### PR DESCRIPTION
## Summary
- run `prisma generate` in the build step and after install
- document production build instructions in README

## Testing
- `npm run lint`
- `npm run build` *(fails: Unable to download fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6853f0324414832880fca1a002aa71cb