### PR TITLE
Fix route types for invoice API

### DIFF
--- a/src/app/api/invoices/[id]/route.ts
+++ b/src/app/api/invoices/[id]/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from 'next/server'
+import { NextResponse, type NextRequest } from 'next/server'
 import { prisma } from '@/lib/prisma'
 
 export async function GET(
-  request: Request,
+  request: NextRequest,
   { params }: { params: { id: string } }
 ) {
   const invoice = await prisma.invoice.findUnique({ where: { id: params.id } })
@@ -13,7 +13,7 @@ export async function GET(
 }
 
 export async function PUT(
-  request: Request,
+  request: NextRequest,
   { params }: { params: { id: string } }
 ) {
   const data = await request.json()
@@ -33,7 +33,7 @@ export async function PUT(
 }
 
 export async function DELETE(
-  request: Request,
+  request: NextRequest,
   { params }: { params: { id: string } }
 ) {
   await prisma.invoice.delete({ where: { id: params.id } })


### PR DESCRIPTION
## Summary
- use `NextRequest` for dynamic invoice route handlers

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853f7692fc48328b4ac4e7b9037256b