### PR TITLE
Switch invoice components to shadcn/ui

### DIFF
--- a/src/components/InvoiceForm.tsx
+++ b/src/components/InvoiceForm.tsx
@@ -1,5 +1,8 @@
 'use client'
 import { useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
 
 export default function InvoiceForm({ onSuccess }: { onSuccess: () => void }) {
   const [form, setForm] = useState({
@@ -31,66 +34,84 @@ export default function InvoiceForm({ onSuccess }: { onSuccess: () => void }) {
     onSuccess()
   }
   return (
-    <form onSubmit={submit} className="space-y-2 border p-4 rounded">
-      <div className="flex flex-col gap-2 sm:flex-row">
-        <input
-          name="clientName"
-          value={form.clientName}
-          onChange={handleChange}
-          placeholder="Client Name"
-          required
-          className="border p-2 rounded flex-1"
-        />
-        <input
-          name="clientEmail"
-          value={form.clientEmail}
-          onChange={handleChange}
-          placeholder="Client Email"
-          className="border p-2 rounded flex-1"
-        />
+    <form onSubmit={submit} className="space-y-4 border p-4 rounded">
+      <div className="flex flex-col gap-4 sm:flex-row">
+        <div className="flex flex-1 flex-col gap-1">
+          <Label htmlFor="clientName">Client Name</Label>
+          <Input
+            id="clientName"
+            name="clientName"
+            value={form.clientName}
+            onChange={handleChange}
+            placeholder="Client Name"
+            required
+          />
+        </div>
+        <div className="flex flex-1 flex-col gap-1">
+          <Label htmlFor="clientEmail">Client Email</Label>
+          <Input
+            id="clientEmail"
+            name="clientEmail"
+            value={form.clientEmail}
+            onChange={handleChange}
+            placeholder="Client Email"
+          />
+        </div>
       </div>
-      <div className="flex flex-col gap-2 sm:flex-row">
-        <input
-          type="date"
-          name="issueDate"
-          value={form.issueDate}
-          onChange={handleChange}
-          required
-          className="border p-2 rounded flex-1"
-        />
-        <input
-          type="date"
-          name="dueDate"
-          value={form.dueDate}
-          onChange={handleChange}
-          required
-          className="border p-2 rounded flex-1"
-        />
+      <div className="flex flex-col gap-4 sm:flex-row">
+        <div className="flex flex-1 flex-col gap-1">
+          <Label htmlFor="issueDate">Issue Date</Label>
+          <Input
+            id="issueDate"
+            type="date"
+            name="issueDate"
+            value={form.issueDate}
+            onChange={handleChange}
+            required
+          />
+        </div>
+        <div className="flex flex-1 flex-col gap-1">
+          <Label htmlFor="dueDate">Due Date</Label>
+          <Input
+            id="dueDate"
+            type="date"
+            name="dueDate"
+            value={form.dueDate}
+            onChange={handleChange}
+            required
+          />
+        </div>
       </div>
-      <div className="flex flex-col gap-2 sm:flex-row">
-        <input
-          type="number"
-          step="0.01"
-          name="amount"
-          value={form.amount}
-          onChange={handleChange}
-          placeholder="Amount"
-          required
-          className="border p-2 rounded flex-1"
-        />
-        <input
-          type="number"
-          step="0.01"
-          name="taxRate"
-          value={form.taxRate}
-          onChange={handleChange}
-          placeholder="Tax Rate"
-          className="border p-2 rounded flex-1"
-        />
+      <div className="flex flex-col gap-4 sm:flex-row">
+        <div className="flex flex-1 flex-col gap-1">
+          <Label htmlFor="amount">Amount</Label>
+          <Input
+            id="amount"
+            type="number"
+            step="0.01"
+            name="amount"
+            value={form.amount}
+            onChange={handleChange}
+            placeholder="Amount"
+            required
+          />
+        </div>
+        <div className="flex flex-1 flex-col gap-1">
+          <Label htmlFor="taxRate">Tax Rate</Label>
+          <Input
+            id="taxRate"
+            type="number"
+            step="0.01"
+            name="taxRate"
+            value={form.taxRate}
+            onChange={handleChange}
+            placeholder="Tax Rate"
+          />
+        </div>
       </div>
-      <button type="submit" disabled={loading} className="bg-blue-600 text-white px-4 py-2 rounded">
+      <Button type="submit" disabled={loading}>
         {loading ? 'Saving...' : 'Create Invoice'}
-      </button>
+      </Button>
     </form>
   )
 }

--- a/src/components/InvoiceList.tsx
+++ b/src/components/InvoiceList.tsx
@@ -1,5 +1,14 @@
 'use client'
 import { useState, useEffect } from 'react'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
 
 export type Invoice = {
   id: string
@@ -28,32 +37,33 @@ export default function InvoiceList({ refreshKey }: { refreshKey: number }) {
   if (!invoices.length) return <p>No invoices yet.</p>
 
   return (
-    <table className="w-full border mt-4">
-      <thead>
-        <tr className="bg-gray-100">
-          <th className="p-2 text-left">Client</th>
-          <th className="p-2 text-left">Amount</th>
-          <th className="p-2 text-left">Status</th>
-          <th className="p-2">Actions</th>
-        </tr>
-      </thead>
-      <tbody>
+    <Table className="border mt-4">
+      <TableHeader>
+        <TableRow className="bg-gray-100">
+          <TableHead className="p-2 text-left">Client</TableHead>
+          <TableHead className="p-2 text-left">Amount</TableHead>
+          <TableHead className="p-2 text-left">Status</TableHead>
+          <TableHead className="p-2 text-center">Actions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
         {invoices.map((inv) => (
-          <tr key={inv.id} className="border-t">
-            <td className="p-2">{inv.clientName}</td>
-            <td className="p-2">{inv.amount}</td>
-            <td className="p-2">{inv.status}</td>
-            <td className="p-2 text-center">
-              <button
-                onClick={() => remove(inv.id)}
+          <TableRow key={inv.id} className="border-t">
+            <TableCell className="p-2">{inv.clientName}</TableCell>
+            <TableCell className="p-2">{inv.amount}</TableCell>
+            <TableCell className="p-2">{inv.status}</TableCell>
+            <TableCell className="p-2 text-center">
+              <Button
+                variant="link"
                 className="text-red-600 hover:underline"
+                onClick={() => remove(inv.id)}
               >
                 Delete
-              </button>
-            </td>
-          </tr>
+              </Button>
+            </TableCell>
+          </TableRow>
         ))}
-      </tbody>
-    </table>
+      </TableBody>
+    </Table>
   )
 }


### PR DESCRIPTION
## Summary
- replace form inputs and buttons with shadcn/ui components
- swap table markup for shadcn Table elements
- show labels for all inputs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854024364d48328936c03ef18c2b0d5