### PR TITLE
Add tabs and invoice modal

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,16 +3,57 @@ import InvoiceForm from '@/components/InvoiceForm'
 import InvoiceList from '@/components/InvoiceList'
 import Dashboard from '@/components/Dashboard'
 import { useState } from 'react'
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/ui/tabs'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
 
 export default function Home() {
   const [refreshKey, setRefreshKey] = useState(0)
+  const [open, setOpen] = useState(false)
   return (
-    <main className="max-w-4xl mx-auto p-4 space-y-8">
+    <main className="max-w-4xl mx-auto p-4 space-y-4">
       <h1 className="text-2xl font-semibold">Dashboard</h1>
-      <Dashboard />
-      <h2 className="text-xl font-semibold">Invoices</h2>
-      <InvoiceForm onSuccess={() => setRefreshKey((k) => k + 1)} />
-      <InvoiceList refreshKey={refreshKey} />
+      <Tabs defaultValue="overview" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="invoices">Invoices</TabsTrigger>
+        </TabsList>
+        <TabsContent value="overview">
+          <Dashboard />
+        </TabsContent>
+        <TabsContent value="invoices" className="space-y-4">
+          <div className="flex justify-end">
+            <Dialog open={open} onOpenChange={setOpen}>
+              <DialogTrigger asChild>
+                <Button>Add Invoice</Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>New Invoice</DialogTitle>
+                </DialogHeader>
+                <InvoiceForm
+                  onSuccess={() => {
+                    setRefreshKey((k) => k + 1)
+                    setOpen(false)
+                  }}
+                />
+              </DialogContent>
+            </Dialog>
+          </div>
+          <InvoiceList refreshKey={refreshKey} />
+        </TabsContent>
+      </Tabs>
     </main>
   )
 }

--- a/src/components/InvoiceForm.tsx
+++ b/src/components/InvoiceForm.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
+import { Toggle } from '@/components/ui/toggle'
 
 export default function InvoiceForm({ onSuccess }: { onSuccess: () => void }) {
   const [form, setForm] = useState({
@@ -11,6 +12,7 @@ export default function InvoiceForm({ onSuccess }: { onSuccess: () => void }) {
     issueDate: '',
     dueDate: '',
     amount: '',
+    status: 'PAID',
   })
   const [loading, setLoading] = useState(false)
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -28,7 +30,14 @@ export default function InvoiceForm({ onSuccess }: { onSuccess: () => void }) {
       }),
     })
     setLoading(false)
-    setForm({ clientName: '', clientEmail: '', issueDate: '', dueDate: '', amount: '' })
+    setForm({
+      clientName: '',
+      clientEmail: '',
+      issueDate: '',
+      dueDate: '',
+      amount: '',
+      status: 'PAID',
+    })
     onSuccess()
   }
   return (
@@ -94,6 +103,17 @@ export default function InvoiceForm({ onSuccess }: { onSuccess: () => void }) {
             required
           />
         </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <Toggle
+          id="status"
+          pressed={form.status === 'PAID'}
+          onPressedChange={(pressed) =>
+            setForm({ ...form, status: pressed ? 'PAID' : 'PENDING' })
+          }
+          aria-label="Mark as paid"
+        />
+        <Label htmlFor="status">Mark as paid</Label>
       </div>
       <Button type="submit" disabled={loading}>
         {loading ? 'Saving...' : 'Create Invoice'}


### PR DESCRIPTION
## Summary
- add status toggle to InvoiceForm
- organize dashboard and invoice list in tabs
- open invoice form in a dialog modal

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685449e91c308328aacd8142dd4c5fe1