### PR TITLE
Update frontend for currency schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ When writing code, please follow these principles:
 
 - Ensure financial accuracy in all calculations (especially taxes).
 - Build with expandability in mind (multi-user, SaaS in the future).
+- Support invoices in multiple currencies (USD and EUR).
 
 ## AI-Driven Requests
 

--- a/src/app/api/invoices/[id]/route.ts
+++ b/src/app/api/invoices/[id]/route.ts
@@ -44,7 +44,6 @@ export async function PUT(
       amountUSD,
       amountEUR,
       exchangeRate: rate,
-      taxRate: data.taxRate,
       status: data.status,
     },
   })

--- a/src/app/api/invoices/route.ts
+++ b/src/app/api/invoices/route.ts
@@ -60,7 +60,6 @@ export async function POST(request: Request) {
       amountUSD,
       amountEUR,
       exchangeRate: rate,
-      taxRate: data.taxRate ?? 0,
       status: data.status ?? 'PENDING',
     },
   })

--- a/src/types/invoice.ts
+++ b/src/types/invoice.ts
@@ -8,6 +8,5 @@ export type Invoice = {
   amountUSD: string
   amountEUR: string
   exchangeRate: number
-  taxRate: number
   status: string
 }


### PR DESCRIPTION
## Summary
- remove outdated `taxRate` field from routes and types
- note multi-currency in development guidelines

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68552a5724048328bceb03a5e665216d