### PR TITLE
Restructure dashboard into clear zones

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,9 @@ Next.js App Router setup for pages and styling implementation
 
 ## UI Structure Notes
 
-- Top-level on the dashboard only show this quarter's income, general deduction, Social Security, IRPF advance (Modelo 130) and net take-home.
-- Yearly totals, bracket breakdowns and other reference data are hidden in an accordion/tab section.
+- Dashboard is split into three visual zones:
+  1. **QuarterSummary** – shows this quarter's income, general deduction, Social Security (quarter), IRPF advance and net take‑home. Can display an optional payment reminder message.
+  2. **YearlyOverview** – reference cards for total income, taxable income, IRPF (state, Madrid and total), Social Security (annual and monthly), effective tax rate and take‑home income (annual and monthly).
+  3. **AdvancedInsights** – accordion sections for quarterly filings, year‑end tax brackets and charts/visuals. Messages like "Income Until Next Bracket" and "SS Band Info" live here.
+- No metric should appear outside its assigned zone.
 - All displayed values must call helpers in `src/lib` for calculations (no inline math beyond formatting).

--- a/README.md
+++ b/README.md
@@ -68,7 +68,20 @@ The dashboard also displays your total annual and monthly tax burden (IRPF + Soc
 
 ## Modelo 130 quarterly filings
 
-Quarterly income is now grouped to estimate IRPF advances (20% of net income after deductions). Logic lives in `src/lib/modelo130.ts` and the dashboard lists each quarter's expected payment. The dashboard prioritizes the current quarter's totals and required payment, while yearly summaries and charts are tucked into an expandable section for reference.
+Quarterly income is now grouped to estimate IRPF advances (20% of net income after deductions). Logic lives in `src/lib/modelo130.ts` and the dashboard lists each quarter's expected payment.
+
+## Dashboard layout
+
+The dashboard is organized into three zones that progressively reveal information:
+
+1. **This Quarter — Action Required** (`QuarterSummary`)
+   - Shows quarterly income, deduction, Social Security, IRPF advance and net take‑home.
+2. **Yearly Summary — Reference Only** (`YearlyOverview`)
+   - Displays totals for income, taxable income, IRPF (state/Madrid/total), Social Security, effective rate and take‑home.
+3. **Advanced Insights** (`AdvancedInsights`)
+   - Accordion panels for quarterly filings, year-end brackets and charts/visuals.
+
+The first zone stays visible so you immediately know what you owe. Other data is still available but separated for clarity.
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 

--- a/src/components/dashboard/AdvancedInsights.tsx
+++ b/src/components/dashboard/AdvancedInsights.tsx
@@ -1,0 +1,167 @@
+"use client"
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '@/components/ui/table'
+import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from '@/components/ui/accordion'
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, PieChart, Pie } from 'recharts'
+import { formatCurrency } from '@/lib/utils'
+import type { Modelo130Quarter } from '@/lib/modelo130'
+import type { IrpfBreakdownEntry } from '@/lib/tax'
+import { getTaxBreakdown } from '@/lib/taxSummary'
+
+export default function AdvancedInsights({
+  currency,
+  filings,
+  breakdown,
+  data,
+  tax,
+  ssAnnual,
+  advancePaid,
+  finalBalance,
+  nextBracketMsg,
+  ssNextMsg,
+  totalIncome,
+}: {
+  currency: 'USD' | 'EUR'
+  filings: Modelo130Quarter[]
+  breakdown: IrpfBreakdownEntry[]
+  data: { name: string; income: number; tax: number }[]
+  tax: number
+  ssAnnual: number
+  advancePaid: number
+  finalBalance: number
+  nextBracketMsg: string
+  ssNextMsg: string
+  totalIncome: number
+}) {
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xl font-semibold">Advanced Insights</h2>
+      <Accordion type="multiple" className="w-full space-y-2">
+        <AccordionItem value="filings">
+          <AccordionTrigger className="text-lg">Quarterly Filings</AccordionTrigger>
+          <AccordionContent>
+            <Card>
+              <CardHeader>
+                <CardTitle>Modelo 130</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Quarter</TableHead>
+                      <TableHead>Income</TableHead>
+                      <TableHead>Deductions</TableHead>
+                      <TableHead>Estimated IRPF</TableHead>
+                      <TableHead>Amount Due</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {filings.map((q) => (
+                      <TableRow key={q.quarter}>
+                        <TableCell>{`Q${q.quarter}`}</TableCell>
+                        <TableCell>{formatCurrency(q.income, currency)}</TableCell>
+                        <TableCell>{formatCurrency(q.deductions, currency)}</TableCell>
+                        <TableCell>{formatCurrency(q.estimatedIrpf, currency)}</TableCell>
+                        <TableCell>{formatCurrency(q.amountDue, currency)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          </AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="brackets">
+          <AccordionTrigger className="text-lg">Year-End Tax Brackets</AccordionTrigger>
+          <AccordionContent className="space-y-2">
+            <Card>
+              <CardHeader>
+                <CardTitle>Tax Bracket Breakdown</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Bracket</TableHead>
+                      <TableHead>Taxable</TableHead>
+                      <TableHead>Rate</TableHead>
+                      <TableHead>Tax</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {breakdown.map((b, i) => (
+                      <TableRow key={i}>
+                        <TableCell>
+                          {`${formatCurrency(b.from, currency)} - ${formatCurrency(b.to, currency)}`}
+                        </TableCell>
+                        <TableCell>{formatCurrency(b.taxable, currency)}</TableCell>
+                        <TableCell>{(b.rate * 100).toFixed(0)}%</TableCell>
+                        <TableCell>{formatCurrency(b.tax, currency)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+                <div className="mt-4 space-y-1 text-sm">
+                  <p>Final IRPF Liability: {formatCurrency(tax, currency)}</p>
+                  <p>Quarterly Advances Paid: {formatCurrency(advancePaid, currency)}</p>
+                  <p className="font-semibold">
+                    {finalBalance >= 0
+                      ? `Balance Due: ${formatCurrency(finalBalance, currency)}`
+                      : `Refund: ${formatCurrency(Math.abs(finalBalance), currency)}`}
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          </AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="charts">
+          <AccordionTrigger className="text-lg">Charts & Visuals</AccordionTrigger>
+          <AccordionContent className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>Monthly Breakdown</CardTitle>
+              </CardHeader>
+              <CardContent className="h-80">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={data}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="name" />
+                    <YAxis />
+                    <Tooltip formatter={(value: number) => formatCurrency(value, currency)} />
+                    <Bar dataKey="income" fill="#8884d8" name="Income" />
+                    <Bar dataKey="tax" fill="#82ca9d" name="Tax" />
+                  </BarChart>
+                </ResponsiveContainer>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Tax vs Take-Home</CardTitle>
+              </CardHeader>
+              <CardContent className="h-80">
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart>
+                    <Tooltip formatter={(value: number) => formatCurrency(value, currency)} />
+                    <Pie data={getTaxBreakdown(totalIncome, tax, ssAnnual)} dataKey="value" nameKey="name" outerRadius={80} fill="#8884d8" label />
+                  </PieChart>
+                </ResponsiveContainer>
+              </CardContent>
+            </Card>
+            <Card className="sm:col-span-3">
+              <CardHeader>
+                <CardTitle>Income Until Next Bracket</CardTitle>
+              </CardHeader>
+              <CardContent>{nextBracketMsg}</CardContent>
+            </Card>
+            <Card className="sm:col-span-3">
+              <CardHeader>
+                <CardTitle>SS Band Info</CardTitle>
+              </CardHeader>
+              <CardContent>{ssNextMsg}</CardContent>
+            </Card>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </section>
+  )
+}

--- a/src/components/dashboard/QuarterSummary.tsx
+++ b/src/components/dashboard/QuarterSummary.tsx
@@ -1,0 +1,61 @@
+"use client"
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { formatCurrency } from '@/lib/utils'
+
+export default function QuarterSummary({
+  currency,
+  quarterIncome,
+  quarterGeneral,
+  ssQuarter,
+  quarterAdvance,
+  quarterNet,
+  nextPaymentMessage,
+}: {
+  currency: 'USD' | 'EUR'
+  quarterIncome: number
+  quarterGeneral: number
+  ssQuarter: number
+  quarterAdvance: number
+  quarterNet: number
+  nextPaymentMessage?: string
+}) {
+  return (
+    <section className="space-y-2">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-5 gap-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>This Quarter Income</CardTitle>
+          </CardHeader>
+          <CardContent>{formatCurrency(quarterIncome, currency)}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>General Deduction</CardTitle>
+          </CardHeader>
+          <CardContent>{formatCurrency(quarterGeneral, currency)}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Social Security (Quarter)</CardTitle>
+          </CardHeader>
+          <CardContent>{formatCurrency(ssQuarter, currency)}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>IRPF Advance (Modelo 130)</CardTitle>
+          </CardHeader>
+          <CardContent>{formatCurrency(quarterAdvance, currency)}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Net Take-Home (Quarter)</CardTitle>
+          </CardHeader>
+          <CardContent>{formatCurrency(quarterNet, currency)}</CardContent>
+        </Card>
+      </div>
+      {nextPaymentMessage && (
+        <p className="text-sm font-medium text-center">{nextPaymentMessage}</p>
+      )}
+    </section>
+  )
+}

--- a/src/components/dashboard/SummaryCardGroup.tsx
+++ b/src/components/dashboard/SummaryCardGroup.tsx
@@ -1,0 +1,4 @@
+"use client"
+export default function SummaryCardGroup({ children }: { children: React.ReactNode }) {
+  return <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">{children}</div>
+}

--- a/src/components/dashboard/YearlyOverview.tsx
+++ b/src/components/dashboard/YearlyOverview.tsx
@@ -1,0 +1,98 @@
+"use client"
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { formatCurrency } from '@/lib/utils'
+import SummaryCardGroup from './SummaryCardGroup'
+
+export default function YearlyOverview({
+  currency,
+  totalIncome,
+  taxableIncome,
+  stateTax,
+  regionalTax,
+  tax,
+  ssAnnual,
+  ssMonthly,
+  effectiveRate,
+  takeHomeAnnual,
+  takeHomeMonthly,
+}: {
+  currency: 'USD' | 'EUR'
+  totalIncome: number
+  taxableIncome: number
+  stateTax: number
+  regionalTax: number
+  tax: number
+  ssAnnual: number
+  ssMonthly: number
+  effectiveRate: number
+  takeHomeAnnual: number
+  takeHomeMonthly: number
+}) {
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xl font-semibold">Yearly Summary</h2>
+      <SummaryCardGroup>
+        <Card>
+          <CardHeader>
+            <CardTitle>Total Income</CardTitle>
+          </CardHeader>
+          <CardContent>{formatCurrency(totalIncome, currency)}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Taxable Income</CardTitle>
+          </CardHeader>
+          <CardContent>{formatCurrency(taxableIncome, currency)}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>IRPF (State)</CardTitle>
+          </CardHeader>
+          <CardContent>{formatCurrency(stateTax, currency)}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>IRPF (Madrid)</CardTitle>
+          </CardHeader>
+          <CardContent>{formatCurrency(regionalTax, currency)}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>IRPF (Total)</CardTitle>
+          </CardHeader>
+          <CardContent>{formatCurrency(tax, currency)}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Social Security (Annual)</CardTitle>
+          </CardHeader>
+          <CardContent>{formatCurrency(ssAnnual, currency)}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Social Security (Monthly)</CardTitle>
+          </CardHeader>
+          <CardContent>{formatCurrency(ssMonthly, currency)}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Effective Tax Rate</CardTitle>
+          </CardHeader>
+          <CardContent>{effectiveRate.toFixed(2)}%</CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Take-Home Income (Annual)</CardTitle>
+          </CardHeader>
+          <CardContent>{formatCurrency(takeHomeAnnual, currency)}</CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Take-Home Income (Monthly)</CardTitle>
+          </CardHeader>
+          <CardContent>{formatCurrency(takeHomeMonthly, currency)}</CardContent>
+        </Card>
+      </SummaryCardGroup>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- split the dashboard into `QuarterSummary`, `YearlyOverview` and `AdvancedInsights` sections
- implement new components for each zone
- refactor `Dashboard` to use the new layout
- document the new UI architecture in `AGENTS.md`
- update `README.md` with dashboard layout information

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68705e846bf88328b54fa9762ff6df53